### PR TITLE
修复导航栏里的订阅链接

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -26,6 +26,7 @@ TAG_FEED_ATOM = None
 FEED_ATOM = None
 FEED_ALL_ATOM = None
 CATEGORY_FEED_ATOM = None
+FEED_URL = 'feeds/mazk.atom.xml'
 
 TWITTER_USERNAME = 'MaZhengke'
 


### PR DESCRIPTION
页面右上角导航栏里的订阅链接仍然指向 `feeds/atom.xml`, 是在[这里](https://github.com/mazk/mazk/blob/dfe2e45948dd3280dc5b5478c11ab8dd730749f0/pelican-bootstrap3/templates/base.html#L223)定义的默认值, 没有被改成`feeds/mazk.atom.xml` 
设置 FEED_URL 选项就好了, 不需要改动模板